### PR TITLE
DrawClipImageが意図した挙動をしない問題

### DIFF
--- a/Assets/Plugins/GameCanvas/Scripts/Engine/Graphic.cs
+++ b/Assets/Plugins/GameCanvas/Scripts/Engine/Graphic.cs
@@ -497,6 +497,11 @@ namespace GameCanvas.Engine
             var img = cRes.GetImg(imageId);
             if (img.Data == null) return;
 
+            x = x - u/2;
+            y = y - v/2;
+            u = u/2;
+            v = v/2;
+
             var l = Mathf.Clamp01((x + u) / mCanvasSize.x);
             var t = Mathf.Clamp01((y + v) / mCanvasSize.y);
             var r = Mathf.Clamp((x + u + width) / mCanvasSize.x, l, 1f);


### PR DESCRIPTION
# 概要
`gc.DrawClipImage()`が意図した挙動をしないため、応急処置として`Graphic.cs`の`DrawClipImage`のx,y,u,vの値を修正する式を追加しました。
これでとりあえず意図した挙動になります。