### PR TITLE
角丸矩形を描画するFillRoundedRectとDrawRoundedRectを追加

### DIFF
--- a/Packages/GameCanvas/Runtime/Scripts/Engine/GcGraphicsEngine.cs
+++ b/Packages/GameCanvas/Runtime/Scripts/Engine/GcGraphicsEngine.cs
@@ -1220,7 +1220,7 @@ namespace GameCanvas.Engine
                 indices[nextIndex++] = (ushort)((cornerResolution + 2) * 2 + 1);
                 indices[nextIndex++] = 1;
                 indices[nextIndex++] = (ushort)((cornerResolution + 2) * 2 + 1);
-                indices[nextIndex++] = (ushort)((cornerResolution + 2) * 4 - 1);
+                indices[nextIndex] = (ushort)((cornerResolution + 2) * 4 - 1);
             }
             mesh.Clear();
             mesh.SetVertices(vertices);

--- a/Packages/GameCanvas/Runtime/Scripts/GcProxy.cs
+++ b/Packages/GameCanvas/Runtime/Scripts/GcProxy.cs
@@ -652,6 +652,15 @@ namespace GameCanvas
         }
 
         /// <inheritdoc/>
+        public float CornerRadius
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => m_Context.Graphics.CornerRadius;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set { m_Context.Graphics.CornerRadius = value; }
+        }
+
+        /// <inheritdoc/>
         public StyleScope StyleScope
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1153,6 +1162,26 @@ namespace GameCanvas
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void FillRect(in GcRect rect)
             => m_Context.Graphics.FillRect(rect);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void FillRoundedRect()
+            => m_Context.Graphics.FillRoundedRect();
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void FillRoundedRect(in float x, in float y, in float width, in float height, float degree = 0f)
+            => m_Context.Graphics.FillRoundedRect(new GcRect(x, y, width, height, math.radians(degree)));
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void FillRoundedRect(in float2 position, in float2 size, float degree = 0f)
+            => m_Context.Graphics.FillRoundedRect(new GcRect(position, size, math.radians(degree)));
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void FillRoundedRect(in GcRect rect)
+            => m_Context.Graphics.FillRoundedRect(rect);
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Packages/GameCanvas/Runtime/Scripts/GcProxy.cs
+++ b/Packages/GameCanvas/Runtime/Scripts/GcProxy.cs
@@ -1071,6 +1071,26 @@ namespace GameCanvas
 
         /// <inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void DrawRoundedRect()
+            => m_Context.Graphics.DrawRoundedRect();
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void DrawRoundedRect(in float x, in float y, in float width, in float height, float degree = 0f)
+            => m_Context.Graphics.DrawRoundedRect(new GcRect(x, y, width, height, math.radians(degree)));
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void DrawRoundedRect(in float2 position, in float2 size, float degree = 0f)
+            => m_Context.Graphics.DrawRoundedRect(new GcRect(position, size, math.radians(degree)));
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void DrawRoundedRect(in GcRect rect)
+            => m_Context.Graphics.DrawRoundedRect(rect);
+
+        /// <inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void DrawString(in string str)
             => m_Context.Graphics.DrawString(str);
 

--- a/Packages/GameCanvas/Runtime/Scripts/Interface/IGraphics.cs
+++ b/Packages/GameCanvas/Runtime/Scripts/Interface/IGraphics.cs
@@ -98,6 +98,11 @@ namespace GameCanvas
         GcAnchor StringAnchor { get; set; }
 
         /// <summary>
+        /// 角丸の半径
+        /// </summary>
+        float CornerRadius { get; set; }
+
+        /// <summary>
         /// <see cref="PushStyle"/> と <see cref="PopStyle"/> が自動的に呼び出されるスコープ
         /// </summary>
         StyleScope StyleScope { get; }
@@ -296,6 +301,17 @@ namespace GameCanvas
         /// </summary>
         /// <param name="rect">矩形</param>
         void FillRect(in GcRect rect);
+
+        /// <summary>
+        /// 角丸矩形を塗りで描画します
+        /// </summary>
+        void FillRoundedRect();
+
+        /// <summary>
+        /// 角丸矩形を塗りで描画します
+        /// </summary>
+        /// <param name="rect">二等辺三角形が収まる矩形</param>
+        void FillRoundedRect(in GcRect rect);
 
         /// <summary>
         /// スタックから座標系（変換行列）を取り出し <see cref="CurrentCoordinate"/> に上書きします
@@ -620,6 +636,24 @@ namespace GameCanvas
         /// <param name="size">大きさ</param>
         /// <param name="degree">回転（度数法）</param>
         void FillRect(in float2 position, in float2 size, float degree = 0f);
+
+        /// <summary>
+        /// 角丸矩形を塗りで描画します
+        /// </summary>
+        /// <param name="x">X座標</param>
+        /// <param name="y">Y座標</param>
+        /// <param name="width">横幅</param>
+        /// <param name="height">縦幅</param>
+        /// <param name="degree">回転（度数法）</param>
+        void FillRoundedRect(in float x, in float y, in float width, in float height, float degree = 0f);
+
+        /// <summary>
+        /// 角丸矩形を塗りで描画します
+        /// </summary>
+        /// <param name="position">位置</param>
+        /// <param name="size">大きさ</param>
+        /// <param name="degree">回転（度数法）</param>
+        void FillRoundedRect(in float2 position, in float2 size, float degree = 0f);
 
         /// <summary>
         /// 画像の縦幅を取得します

--- a/Packages/GameCanvas/Runtime/Scripts/Interface/IGraphics.cs
+++ b/Packages/GameCanvas/Runtime/Scripts/Interface/IGraphics.cs
@@ -232,6 +232,17 @@ namespace GameCanvas
         void DrawRect(in GcRect rect);
 
         /// <summary>
+        /// 角丸矩形を線で描画します
+        /// </summary>
+        void DrawRoundedRect();
+
+        /// <summary>
+        /// 角丸矩形を線で描画します
+        /// </summary>
+        /// <param name="rect">二等辺三角形が収まる矩形</param>
+        void DrawRoundedRect(in GcRect rect);
+
+        /// <summary>
         /// 文字列を描画します
         /// </summary>
         /// <param name="str">描画する文字列</param>
@@ -564,6 +575,24 @@ namespace GameCanvas
         /// <param name="size">大きさ</param>
         /// <param name="degree">回転（度数法）</param>
         void DrawRect(in float2 position, in float2 size, float degree = 0f);
+
+        /// <summary>
+        /// 角丸矩形を線で描画します
+        /// </summary>
+        /// <param name="x">X座標</param>
+        /// <param name="y">Y座標</param>
+        /// <param name="width">横幅</param>
+        /// <param name="height">縦幅</param>
+        /// <param name="degree">回転（度数法）</param>
+        void DrawRoundedRect(in float x, in float y, in float width, in float height, float degree = 0f);
+
+        /// <summary>
+        /// 角丸矩形を線で描画します
+        /// </summary>
+        /// <param name="position">位置</param>
+        /// <param name="size">大きさ</param>
+        /// <param name="degree">回転（度数法）</param>
+        void DrawRoundedRect(in float2 position, in float2 size, float degree = 0f);
 
         [System.Obsolete("Use to `DrawString`  instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Packages/GameCanvas/Runtime/Scripts/Struct/GcStyle.cs
+++ b/Packages/GameCanvas/Runtime/Scripts/Struct/GcStyle.cs
@@ -25,7 +25,8 @@ namespace GameCanvas
             LineCap = GcLineCap.Butt,
             LineWidth = 1f,
             RectAnchor = GcAnchor.UpperLeft,
-            StringAnchor = GcAnchor.UpperLeft
+            StringAnchor = GcAnchor.UpperLeft,
+            CornerRadius = 10
         };
 
         public int CircleResolution;
@@ -35,6 +36,7 @@ namespace GameCanvas
         public float LineWidth;
         public GcAnchor RectAnchor;
         public GcAnchor StringAnchor;
+        public float CornerRadius;
 
         public bool Equals(GcStyle other)
             => CircleResolution.Equals(other.CircleResolution)
@@ -43,7 +45,8 @@ namespace GameCanvas
             && (LineCap == other.LineCap)
             && LineWidth.Equals(other.LineWidth)
             && (RectAnchor == other.RectAnchor)
-            && (StringAnchor == other.StringAnchor);
+            && (StringAnchor == other.StringAnchor)
+            && (CornerRadius == other.CornerRadius);
 
         public override bool Equals(object obj)
             => (obj is GcStyle other) && Equals(other);
@@ -55,6 +58,7 @@ namespace GameCanvas
             ^ ((int)LineCap)
             ^ LineWidth.GetHashCode()
             ^ (int)RectAnchor
-            ^ (int)StringAnchor;
+            ^ (int)StringAnchor
+            ^ CornerRadius.GetHashCode();
     }
 }


### PR DESCRIPTION
DrawRoundedRectを実装する前に練習としてFillRoundedRectを実装しました。

## 実装内容
* 角丸矩形を塗りで描画するFillRoundedRectメソッドを追加
 * FillRectと同様にCGRectを引数として受け取る
 * アンカー指定に対応
* 角丸矩形の角丸に使用する円の半径を指定するCornerRadiusプロパティを追加
 * デフォルト値は10に設定
 * 角丸矩形の角丸に使用する円の解像度はFillCircleなどと同じCircleResolutionプロパティの値を使用 (実装簡易化のため4の倍数に丸めて使用)

## 使用例
![スクリーンショット 2021-02-13 20 28 29](https://user-images.githubusercontent.com/2297122/107848844-1b4b2480-6e3a-11eb-893d-c8dfa28aa0ea.png)
<img width="503" alt="スクリーンショット 2021-02-13 20 28 39" src="https://user-images.githubusercontent.com/2297122/107848847-1dad7e80-6e3a-11eb-88b0-964efb95944e.png">

## メッシュの描画方法
* 四隅の角丸部分は円と同様の方法で扇形、その他の部分は3つの四角形で構成
* 右下の扇形を構成する頂点から順に反時計回りに頂点番号を振りながら扇形を構成するメッシュを構築した後、頂点を決め打ちで再利用して残りの四角形を構成するメッシュを構築
![スクリーンショット 2021-02-13 20 34 23](https://user-images.githubusercontent.com/2297122/107848929-e12e5280-6e3a-11eb-9de9-ba6acac28c88.png)
